### PR TITLE
GitHub Action Container Build & Push (wip)

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,32 @@
+# used the following resources:
+# https://docs.github.com/en/free-pro-team@latest/actions/quickstart
+# https://github.com/docker/login-action#github-container-registry
+# https://github.com/marketplace/actions/build-and-push-docker-images#push-to-multi-registries
+name: ci
+
+on:
+  push:
+    branches: main
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      -
+        name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            duckfat/spongebobify:latest
+            # TODO: get git hash tagging working

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+    -   id: black

--- a/README.md
+++ b/README.md
@@ -3,7 +3,14 @@
 Converts text to Spongebob chicken meme mocking case. On your discord server, invoke using `!spongify Python is a great scripting language`
 
 ## Getting Started
-
+```bash
+pip install -r requirements-dev.txt
+# create a git pre-commit hook for linting
+pre-commit install
+# run it once (should be a noop)
+pre-commit run --all-files
+```
+### Running the Bot using Docker
 The bot needs a token. Someone should write better words on how to generate the token. For now, ask Eric for the token. Once you have a token, you can build the bot from the root of the repo:
 
 ```

--- a/README.md
+++ b/README.md
@@ -3,14 +3,6 @@
 Converts text to Spongebob chicken meme mocking case. On your discord server, invoke using `!spongify Python is a great scripting language`
 
 ## Getting Started
-```bash
-pip install -r requirements-dev.txt
-# create a git pre-commit hook for linting
-pre-commit install
-# run it once (should be a noop)
-pre-commit run --all-files
-```
-### Running the Bot using Docker
 The bot needs a token. Someone should write better words on how to generate the token. For now, ask Eric for the token. Once you have a token, you can build the bot from the root of the repo:
 
 ```
@@ -24,3 +16,11 @@ docker run -e SPONGE_SECRET={token here} -dt spongebot
 ```
 
 If started successfully, the bot should show as online in the Discord server.
+## Contributing
+```bash
+pip install -r requirements-dev.txt
+# create a git pre-commit hook for linting
+pre-commit install
+# run it once (should be a noop)
+pre-commit run --all-files
+```

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ bot = commands.Bot(command_prefix="!spong")
 @bot.command(name="ify")
 async def _convert(ctx, *phrase):
     print("the fuck")
-    unaltered = ''.join(phrase) if len(phrase) == 1 else ' '.join(phrase)
+    unaltered = "".join(phrase) if len(phrase) == 1 else " ".join(phrase)
     lowered = unaltered.lower()
     alt_cased = []
     cap_chance = INIT_CAP_CHANCE
@@ -24,18 +24,20 @@ async def _convert(ctx, *phrase):
             alt_cased.append(c.upper())
         else:
             alt_cased.append(c)
-    alt_cased = ''.join(alt_cased)
+    alt_cased = "".join(alt_cased)
     print(alt_cased)
     if BOT_ENABLED:
         await ctx.send(alt_cased)
     return alt_cased
 
+
 def internet_on():
     try:
-        urllib.request.urlopen('http://216.58.192.142', timeout=1)
+        urllib.request.urlopen("http://216.58.192.142", timeout=1)
         return True
     except urllib.request.URLError as err:
         return False
+
 
 if internet_on():
     print("Got network!")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+black
+pre-commit


### PR DESCRIPTION
Sets up a basic workflow for building the project and publishing it to the github container registry

Would be nice if we could figure out a local check of the workflow using https://github.com/nektos/act

**_currently branched off of https://github.com/duck-fat/Spongebobify/pull/1, needs a rebase before merging_**